### PR TITLE
fix(activity-card): show absolute datetime as tooltip on hover

### DIFF
--- a/custom_components/lockly/frontend/lockly-activity-card.js
+++ b/custom_components/lockly/frontend/lockly-activity-card.js
@@ -79,6 +79,12 @@ function relativeTime(isoString) {
   return `${diffDay}d ago`;
 }
 
+function absoluteTime(isoString) {
+  const d = new Date(isoString);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleString();
+}
+
 function escapeHtml(str) {
   const div = document.createElement("div");
   div.textContent = str;
@@ -395,6 +401,7 @@ class LocklyActivityCard extends HTMLElement {
     const who = userName || slotId || "";
     const source = evt.source ? SOURCE_LABELS[evt.source] || evt.source : "";
     const time = evt.timestamp ? relativeTime(evt.timestamp) : "";
+    const timeTitle = evt.timestamp ? absoluteTime(evt.timestamp) : "";
 
     let iconClass = "la-other";
     if (action.includes("unlock") || action === "key_unlock") {
@@ -428,7 +435,12 @@ class LocklyActivityCard extends HTMLElement {
           const unlockTime = lastUnlock.timestamp
             ? relativeTime(lastUnlock.timestamp)
             : "";
-          const timeSuffix = unlockTime ? ` (${unlockTime})` : "";
+          const unlockTitle = lastUnlock.timestamp
+            ? absoluteTime(lastUnlock.timestamp)
+            : "";
+          const timeSuffix = unlockTime
+            ? ` (<span title="${escapeHtml(unlockTitle)}">${unlockTime}</span>)`
+            : "";
           metaParts.push(
             `Last unlocked by ${escapeHtml(unlockWho)}${timeSuffix}`
           );
@@ -445,7 +457,7 @@ class LocklyActivityCard extends HTMLElement {
           <div class="la-action-line">${lockName} &middot; ${escapeHtml(label)}</div>
           ${metaParts.length ? `<div class="la-meta">${metaParts.join(" ")}</div>` : ""}
         </div>
-        <div class="la-time">${time}</div>
+        <div class="la-time"${timeTitle ? ` title="${escapeHtml(timeTitle)}"` : ""}>${time}</div>
       </div>`;
   }
 }


### PR DESCRIPTION
## Summary
- Hovering the relative time in lockly-activity-card (e.g. "2h ago", "3d ago") now reveals the full local datetime via a `title` tooltip.
- Same tooltip applied to the inline "Last unlocked by ... (Xh ago)" suffix in the meta line.
- New `absoluteTime()` helper alongside `relativeTime()`; uses `toLocaleString()` so it picks up the user's HA locale.
- No card config knob added — tooltip is always on.

Closes #67.

## Test plan
- [ ] Open a dashboard with the lockly activity card, hover over a "Xh ago" timestamp — expect to see absolute local date+time tooltip.
- [ ] Hover over the "(Xh ago)" suffix in a "Last unlocked by ..." line — same tooltip.
- [ ] Confirm relative-time text is unchanged (no inline date breaking layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)