### PR TITLE
fix(scripts): resolve git via shutil.which to satisfy ruff S607

### DIFF
--- a/scripts/customize.py
+++ b/scripts/customize.py
@@ -84,19 +84,21 @@ def read_origin_from_git_config(repo_root: Path) -> str | None:
                     return url
 
     # Case 3: fallback to calling git
-    try:
-        proc = subprocess.run(
-            ("git", "config", "--get", "remote.origin.url"),
-            cwd=str(repo_root),
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        url = (proc.stdout or "").strip()
-        if url:
-            return url
-    except (FileNotFoundError, OSError):
-        pass
+    git_bin = shutil.which("git")
+    if git_bin:
+        try:
+            proc = subprocess.run(  # noqa: S603 — git_bin is PATH-resolved, args are static
+                (git_bin, "config", "--get", "remote.origin.url"),
+                cwd=str(repo_root),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            url = (proc.stdout or "").strip()
+            if url:
+                return url
+        except OSError:
+            pass
 
     return None
 


### PR DESCRIPTION
## Summary
- `Lint` workflow on `main` is currently failing on `scripts/customize.py:89` — ruff `S607` (partial executable path).
- Resolve `git` through `shutil.which()` and pass the absolute path; tag `# noqa: S603` for the unavoidable subprocess-with-variable warning that surfaces once S607 is gone (args are static, binary path is PATH-resolved).
- Unblocks PRs against `main` (e.g. #68).

## Test plan
- [x] `python3 -m ruff check .` — clean
- [x] `python3 -m ruff format . --check` — clean
- [x] Local pre-commit (ruff, format, eof, trailing whitespace, pytest) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)