### PR TITLE
chore(dev): pin HA helper deps + document version sentinel

### DIFF
--- a/custom_components/lockly/const.py
+++ b/custom_components/lockly/const.py
@@ -20,6 +20,23 @@ def _resolve_version() -> str:
 
     Called once at module load (before the event loop starts) so the
     result is cached and never triggers blocking I/O inside async code.
+
+    `manifest.json` is checked in with ``"version": "0.0.0"`` as a sentinel for
+    "unreleased source." The release workflow (.github/workflows/release.yml,
+    step "Adjust version number") rewrites it to the actual tag via ``yq``
+    before zipping the integration, so HACS installs see the real version.
+    JSON has no comment syntax, so this rationale lives here.
+
+    When the sentinel is detected, we fall back to the mtime of
+    ``frontend/lockly-card.js`` so the returned value still changes whenever
+    the frontend bundle does. The value is consumed as the ``?v=`` cache
+    buster on the registered Lovelace JS resources, ensuring browsers
+    re-fetch after a frontend edit.
+
+    Known limitation: only ``lockly-card.js``'s mtime is consulted, so editing
+    only another frontend file (e.g. ``lockly-activity-card.js``) does NOT
+    bump the cache buster. Browsers may keep serving stale JS until a forced
+    reload. See issue #67 / commit 58f12f1 for context.
     """
     version = "0.0.0"
     with (

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,18 @@ pytest-homeassistant-custom-component
 ruff==0.15.12
 pre_commit==4.6.0
 yq==3.4.3
+
+# HA's helpers/service.py:_base_components() eagerly imports a hardcoded set of
+# components during services.yaml validation. `pip install homeassistant` does
+# not pull their per-integration deps (HA installs those lazily during setup,
+# but this code path bypasses that machinery), so we install them here.
+# Pins match HA's per-integration manifest.json values — these are chosen
+# for compatibility with the system libs HA assumes (e.g. libjpeg-turbo 2.x
+# for PyTurboJPEG 1.x), so they should be bumped in lockstep with HA itself.
+PyTurboJPEG==1.8.0
+ha-ffmpeg==3.2.2
+hassil==3.5.0
+home-assistant-intents==2026.3.3
+mutagen==1.47.0
+pymicro-vad==1.0.1
+pyspeex-noise==1.0.2


### PR DESCRIPTION
## Summary

Two dev-environment fixes that came out of debugging why `scripts/develop` hung HA 2026.3.1 at the "loading data" spinner in a fresh devcontainer.

**`requirements.txt`** — pin 7 packages (`hassil`, `mutagen`, `home-assistant-intents`, `PyTurboJPEG`, `ha-ffmpeg`, `pymicro-vad`, `pyspeex-noise`) needed by HA's `helpers/service.py:_base_components()`. That function eagerly imports a hardcoded set of components (`ai_task`, `assist_satellite`, `camera`, etc.) during `services.yaml` validation, which transitively imports their Python modules — but those modules' deps are *not* hard requirements of `homeassistant`. HA's own runtime auto-installer doesn't fire either, since those integrations are never formally set up. Result: `get_services` WS handler errors → frontend spinner hangs forever.

Pins match HA upstream's per-integration `manifest.json` values. Those pins are chosen for system-lib compatibility (e.g. `PyTurboJPEG==1.8.0` because Debian's `libturbojpeg0` is 2.x and `PyTurboJPEG>=2.0` requires libjpeg-turbo 3.x), so they must move in lockstep with the `homeassistant==` pin.

**`custom_components/lockly/const.py`** — extend the `_resolve_version` docstring documenting why `manifest.json` ships `"version": "0.0.0"` (release CI rewrites it via `yq` — JSON has no comment syntax) and the `lockly-card.js` mtime fallback used as the Lovelace cache buster. Includes the known limitation that the fallback consults only `lockly-card.js`'s mtime, so edits to other frontend files (e.g. `lockly-activity-card.js`) do not bump the cache buster — the trap that bit us in #67 / 58f12f1.

## Test plan

- [ ] Build a fresh devcontainer and run `scripts/develop`; HA boots without `ModuleNotFoundError` for `hassil` / `mutagen` / `home_assistant_intents` / `turbojpeg` / `haffmpeg` / `pymicro_vad`.
- [ ] HA onboarding "loading data" step completes (previously hung).
- [ ] No `libturbojpeg` runtime error from the camera integration.
- [ ] (no behavioral change from the const.py change — docs only)