### PR TITLE
chore(devcontainer): disable xterm focus-reporting in shell

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -10,3 +10,8 @@ python3 -m pip install --upgrade pip -r requirements.txt
 sudo npm install -g concurrently
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo BINDIR=/usr/local/bin bash
 pre-commit install
+
+# Disable xterm focus-reporting on shell startup. Some TUIs (notably tmux on
+# the host) leave it enabled, leaking ^[[O / ^[[I sequences into the prompt
+# on focus changes. Idempotent — only appends if not already present.
+grep -qF '1004l' ~/.bashrc || echo "printf '\e[?1004l'" >> ~/.bashrc


### PR DESCRIPTION
## Summary

Append a one-liner to `~/.bashrc` from `scripts/setup` so every new shell in the devcontainer disables xterm focus-reporting (`CSI ? 1004 l`).

Some host TUIs (notably `tmux`) enable focus-reporting and don't clean up on exit, so the devcontainer shell then receives `^[[O` / `^[[I` sequences whenever the user changes window focus and shows them inline in the prompt. Disabling on every shell startup makes the symptom go away regardless of what the host TUI left behind.

The append in `scripts/setup` is idempotent — guarded with `grep -qF '1004l'` — so re-running the setup script does not duplicate the line.

## Test plan

- [ ] In a fresh devcontainer, `scripts/setup` runs and appends the line to `~/.bashrc`.
- [ ] New shells in the container no longer print `^[[O` / `^[[I` when focus changes.
- [ ] Re-running `scripts/setup` does not append the line a second time.