### PR TITLE
chore(devcontainer): pre-seed MQTT config entry on dev-server boot

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -20,5 +20,6 @@ logger:
   logs:
     custom_components.lockly: debug
 
-# MQTT is configured via the UI (Settings > Integrations > MQTT).
-# After first launch, add MQTT with broker: localhost, port: 1883.
+# MQTT is pre-seeded as a config entry by scripts/develop (which invokes
+# scripts/seed_dev_mqtt.py), pointing at localhost:1883. To re-seed, delete
+# .storage/core.config_entries before re-running scripts/develop.

--- a/scripts/develop
+++ b/scripts/develop
@@ -32,6 +32,11 @@ for arg in "$@"; do
     esac
 done
 
+# Pre-seed an MQTT config entry pointing at the local broker so a fresh
+# devcontainer comes up usable without the manual "Add Integration -> MQTT"
+# click after onboarding. Idempotent: no-op if an MQTT entry already exists.
+python3 scripts/seed_dev_mqtt.py
+
 COMMANDS=(
     "mosquitto -c ${MQTT_CONF}"
     "hass --config ${CONFIG_DIR} --debug"

--- a/scripts/seed_dev_mqtt.py
+++ b/scripts/seed_dev_mqtt.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Seed config/.storage/core.config_entries with an MQTT entry for dev use.
+
+Hooked into scripts/develop ahead of `hass` so a fresh devcontainer comes
+up already pointing at the local mosquitto broker, skipping the manual
+"Settings > Devices & Services > Add Integration > MQTT" click-through
+after onboarding completes.
+
+Idempotent: if an MQTT entry already exists in core.config_entries, do
+nothing. Safe to leave wired into scripts/develop permanently.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+STORAGE_DIR = CONFIG_DIR / ".storage"
+ENTRIES_PATH = STORAGE_DIR / "core.config_entries"
+
+# Crockford base32, matching homeassistant.util.ulid.ulid_now() so the entry
+# id we generate is indistinguishable from one HA would have written itself.
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _ulid() -> str:
+    ts_ms = int(time.time() * 1000)
+    rand = int.from_bytes(os.urandom(10), "big")
+    val = (ts_ms << 80) | rand
+    out: list[str] = []
+    for _ in range(26):
+        out.append(_CROCKFORD[val & 0x1F])
+        val >>= 5
+    return "".join(reversed(out))
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _new_mqtt_entry() -> dict:
+    now = _now()
+    return {
+        "created_at": now,
+        "data": {"broker": "localhost", "port": 1883},
+        "disabled_by": None,
+        "discovery_keys": {},
+        "domain": "mqtt",
+        "entry_id": _ulid(),
+        "minor_version": 1,
+        "modified_at": now,
+        "options": {},
+        "pref_disable_new_entities": False,
+        "pref_disable_polling": False,
+        "source": "user",
+        "subentries": [],
+        "title": "Mosquitto (dev)",
+        "unique_id": None,
+        "version": 2,
+    }
+
+
+def main() -> int:
+    """Seed core.config_entries with an MQTT entry; exit 0 on success."""
+    STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+    if ENTRIES_PATH.exists():
+        payload = json.loads(ENTRIES_PATH.read_text())
+        entries = payload.get("data", {}).get("entries", [])
+        if any(e.get("domain") == "mqtt" for e in entries):
+            print("[seed_dev_mqtt] MQTT entry already present, skipping.")
+            return 0
+        entries.append(_new_mqtt_entry())
+        payload["data"]["entries"] = entries
+    else:
+        payload = {
+            "version": 1,
+            "minor_version": 5,
+            "key": "core.config_entries",
+            "data": {"entries": [_new_mqtt_entry()]},
+        }
+    ENTRIES_PATH.write_text(json.dumps(payload, indent=2))
+    rel = ENTRIES_PATH.relative_to(CONFIG_DIR.parent)
+    print(f"[seed_dev_mqtt] Seeded MQTT entry into {rel}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Walking through "Settings → Devices & Services → Add Integration → MQTT" after every onboarding (or every fresh container) is friction the dev workflow doesn't need — the broker is always `localhost:1883` and the simulator already targets that endpoint.

This PR adds `scripts/seed_dev_mqtt.py`, a stdlib-only helper that writes a single MQTT config entry into `config/.storage/core.config_entries` pointing at `localhost:1883`. The entry shape matches the JSON HA 2026.3.1 writes when the entry is added via the UI (sampled from a live storage file, including a Crockford-base32 ULID `entry_id` and the `version: 2 / minor_version: 1` pair MQTT currently uses).

The helper is idempotent — it skips when an MQTT entry already exists and no-ops on a fresh config without disturbing other entries — and is hooked into `scripts/develop` ahead of the `concurrently` invocation so it runs before HA reads the storage file. The `configuration.yaml` comment is updated to describe the new behavior.

### Caveat — coupled to HA's storage schema

The entry shape is HA-version-coupled (the `version: 2 / minor_version: 1` pair, the field set including `subentries: []` and `discovery_keys: {}`). If HA bumps the MQTT integration's storage version, this seeder needs the same bump. Mitigation: re-sample from a live storage file after the next HA upgrade and update the constants. Not catching this would manifest as the seeder writing an entry HA rejects on load.

## Test plan

- [x] Run against the live config with an existing MQTT entry → reports `"already present, skipping"`, file untouched.
- [x] Run against a fresh tmp `config/` dir → writes a syntactically valid entry; second run is idempotent.
- [ ] Delete `config/.storage/` in a fresh devcontainer, run `scripts/develop`, walk through onboarding → MQTT integration is already present, no manual "Add Integration → MQTT" needed, Lockly integration sets up cleanly because MQTT is up.