### PR TITLE
chore(devcontainer): check in mosquitto broker configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage.xml
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+!config/mosquitto.conf
+!config/mosquitto-verbose.conf

--- a/config/mosquitto-verbose.conf
+++ b/config/mosquitto-verbose.conf
@@ -1,0 +1,6 @@
+listener 1883 0.0.0.0
+allow_anonymous true
+persistence false
+log_dest stdout
+log_type all
+connection_messages true

--- a/config/mosquitto.conf
+++ b/config/mosquitto.conf
@@ -1,0 +1,4 @@
+listener 1883 0.0.0.0
+allow_anonymous true
+persistence false
+log_dest stdout


### PR DESCRIPTION
## Summary

`scripts/develop` invokes `mosquitto -c config/mosquitto.conf` (or the `-verbose.conf` variant when `--mqtt-verbose` is passed), but both files were caught by the `config/*` rule in `.gitignore`. On any fresh checkout — or after `git clean -fd` — mosquitto refuses to start with `Unable to open config file`, and `concurrently --kill-others` tears the entire dev-server stack down before HA even gets past the WebSocket handshake.

Add an exception for the two `mosquitto*.conf` files and check in minimal broker configs:

- `mosquitto.conf` — anonymous listener on `0.0.0.0:1883`, no persistence, stdout logging
- `mosquitto-verbose.conf` — same plus `log_type all` + `connection_messages true` for full protocol tracing

Both are dev-only — the broker binds inside the devcontainer, never exposed to a real network — so anonymous auth is fine.

This completes the dev-server bootstrap sequence: with the four recent PRs (#71 helper deps, #72 focus-reporting, #73 MQTT seeder, this one) a fresh devcontainer's `scripts/setup` + `scripts/develop` should bring up MQTT + HA + simulator with no manual steps beyond HA's first-launch onboarding.

## Test plan

- [x] `git clean -fd` then `scripts/develop` on this branch — mosquitto starts cleanly, dev stack stays up.
- [ ] Fresh devcontainer rebuild on this branch (off main with prior 3 PRs merged) — `scripts/develop` runs end-to-end without manual file creation.