### PR TITLE
feat(card): Edit Slot save-as-draft + Save/Apply button

### DIFF
--- a/custom_components/lockly/frontend/lockly-card.js
+++ b/custom_components/lockly/frontend/lockly-card.js
@@ -540,6 +540,7 @@ class LocklyCard extends HTMLElement {
     `;
     this._dialog.addEventListener("closed", () => {
       this._editingSlotId = null;
+      this._originalSlot = null;
       this._dialog?.remove();
       this._dialog = null;
     });
@@ -555,15 +556,21 @@ class LocklyCard extends HTMLElement {
     this._dialog
       .querySelector("#lockly-slot-save")
       ?.addEventListener("click", () => this._saveEditor());
+    const nameField = this._dialog.querySelector("#lockly-slot-name");
     const pinField = this._dialog.querySelector("#lockly-slot-pin");
+    const enabledField = this._dialog.querySelector("#lockly-slot-enabled");
+    const refresh = () => this._refreshButtonState();
+    nameField?.addEventListener("input", refresh);
     if (pinField) {
       pinField.addEventListener("input", () => {
         const digits = pinField.value.replace(/\D+/g, "");
         if (pinField.value !== digits) {
           pinField.value = digits;
         }
+        refresh();
       });
     }
+    enabledField?.addEventListener("change", refresh);
   }
 
   _openEditor(slot) {
@@ -572,6 +579,11 @@ class LocklyCard extends HTMLElement {
     }
     this._ensureDialog();
     this._editingSlotId = slot.id;
+    this._originalSlot = {
+      name: slot.name || "",
+      pin: slot.pin || "",
+      enabled: Boolean(slot.enabled),
+    };
     const nameField = this._dialog.querySelector("#lockly-slot-name");
     const pinField = this._dialog.querySelector("#lockly-slot-pin");
     const enabledField = this._dialog.querySelector("#lockly-slot-enabled");
@@ -585,10 +597,48 @@ class LocklyCard extends HTMLElement {
     if (enabledField) {
       enabledField.checked = Boolean(slot.enabled);
     }
+    this._refreshButtonState();
     this._openDialog();
     if (nameField && !nameField.value) {
       requestAnimationFrame(() => nameField.focus?.());
     }
+  }
+
+  _computeFormState() {
+    if (!this._dialog || !this._originalSlot) {
+      return null;
+    }
+    const nameField = this._dialog.querySelector("#lockly-slot-name");
+    const pinField = this._dialog.querySelector("#lockly-slot-pin");
+    const enabledField = this._dialog.querySelector("#lockly-slot-enabled");
+    const cur = {
+      name: nameField?.value ?? "",
+      pin: (pinField?.value ?? "").trim(),
+      enabled: Boolean(enabledField?.checked),
+    };
+    const orig = this._originalSlot;
+    const nameChanged = cur.name !== orig.name;
+    const pinChanged = cur.pin !== orig.pin;
+    const enabledChanged = cur.enabled !== orig.enabled;
+    return {
+      cur,
+      changed: nameChanged || pinChanged || enabledChanged,
+      // Push to the lock when its state will materially differ: the
+      // enabled flag flipped, or the user is rotating a pin on a slot
+      // that is/will be active. Pure name edits and "draft" pin edits
+      // on a disabled slot are HA-side only.
+      shouldApply: enabledChanged || (cur.enabled && pinChanged),
+    };
+  }
+
+  _refreshButtonState() {
+    const state = this._computeFormState();
+    const saveBtn = this._dialog?.querySelector("#lockly-slot-save");
+    if (!state || !saveBtn) {
+      return;
+    }
+    saveBtn.textContent = state.shouldApply ? "Apply" : "Save";
+    saveBtn.disabled = !state.changed;
   }
 
   _openDialog() {
@@ -658,6 +708,8 @@ class LocklyCard extends HTMLElement {
       this._setPinError(pinField, "");
     }
     const enabled = enabledField ? enabledField.checked : false;
+    const formState = this._computeFormState();
+    const shouldApply = formState ? formState.shouldApply : true;
     try {
       await this._hass.callService("lockly", "update_slot", {
         entry_id: this._config.entry_id,
@@ -671,21 +723,23 @@ class LocklyCard extends HTMLElement {
       console.error("Lockly update failed", err);
       return;
     }
-    const applyData = {
-      entry_id: this._config.entry_id,
-      slot: this._editingSlotId,
-      dry_run: Boolean(this._config?.dry_run),
-    };
-    const lockEntities = this._getLockEntityOverrides();
-    if (lockEntities) {
-      applyData.lock_entities = lockEntities;
-    }
-    try {
-      await this._hass.callService("lockly", "apply_slot", applyData);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("Lockly apply failed", err);
-      return;
+    if (shouldApply) {
+      const applyData = {
+        entry_id: this._config.entry_id,
+        slot: this._editingSlotId,
+        dry_run: Boolean(this._config?.dry_run),
+      };
+      const lockEntities = this._getLockEntityOverrides();
+      if (lockEntities) {
+        applyData.lock_entities = lockEntities;
+      }
+      try {
+        await this._hass.callService("lockly", "apply_slot", applyData);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("Lockly apply failed", err);
+        return;
+      }
     }
     this._closeDialog();
   }


### PR DESCRIPTION
## Summary

Hitting Apply on a freshly-added slot with name+PIN but Enabled left off used to send a `user_enabled: false` delete to the lock — confusing UX for a slot the user was just setting up, and noisy in the activity log.

This PR:

1. Treats the "PIN saved but disabled" case as a **draft** — the slot is persisted to HA storage, but no MQTT publish happens. The lock only hears about the slot once Enabled actually flips on.
2. Splits the action button into **Save** vs **Apply** based on whether the lock has a real state delta to receive, and disables the button when there are no changes at all.

The rule:

| Change | Button |
|---|---|
| Name only | Save |
| PIN, slot stays disabled (draft) | Save |
| Enabled flipped (on or off) | Apply |
| PIN changed on an active slot | Apply |
| No effective change | Save (disabled) |

Equivalent: **Apply** when `enabled` changed OR (target `enabled` = true AND `pin` changed). The card snapshots the slot's pre-edit state when the dialog opens, recomputes on every keystroke/toggle, and updates the button label + disabled live.

## Test plan

- [x] Open Edit on existing slot, change nothing → button is **Save**, disabled
- [x] Change name only → **Save**, click → HA storage updated, no MQTT
- [x] Change PIN on disabled slot → **Save**, click → HA storage updated, lock untouched
- [x] Toggle Enabled on (with PIN) → **Apply**, click → updates + pushes to lock
- [x] Rotate PIN on enabled slot → **Apply**, click → updates + pushes new PIN
- [x] Disable an active slot → **Apply**, click → updates + pushes delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)