### PR TITLE
Catch lockly up with the latest Home Assistant

### DIFF
--- a/custom_components/lockly/activity.py
+++ b/custom_components/lockly/activity.py
@@ -211,3 +211,18 @@ class ActivityBuffer:
         if self._save_unsub is not None:
             return
         self._save_unsub = async_call_later(self._hass, 1, self._async_save)
+
+    async def async_stop(self) -> None:
+        """Cancel the pending debounced save and flush once if dirty.
+
+        Without this hook the ``async_call_later`` timer from
+        ``_schedule_save`` survives past test/integration teardown, which
+        HA's stricter ``verify_cleanup`` (2026.5.x +
+        pytest-homeassistant-custom-component 0.13.330) reports as a
+        lingering job. Flushing on stop also means any final events that
+        landed in the debounce window are persisted instead of dropped.
+        """
+        if self._save_unsub is not None:
+            self._save_unsub()
+            self._save_unsub = None
+            await self._async_save()

--- a/custom_components/lockly/manager.py
+++ b/custom_components/lockly/manager.py
@@ -705,6 +705,8 @@ class LocklyManager:
             if handle is not None:
                 handle.cancel()
         self._pending_actions.clear()
+        if self._activity is not None:
+            await self._activity.async_stop()
 
     async def _enqueue_publish(
         self, lock_name: str, slot_id: int, payload: dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 colorlog==6.10.1
-homeassistant==2026.3.1
-home-assistant-frontend==20260429.3
+homeassistant==2026.5.1
+home-assistant-frontend==20260429.4
 paho-mqtt==2.1.0
 pip==26.1.1
-pytest==9.0.0
-pytest-homeassistant-custom-component
+pytest==9.0.3
+pytest-homeassistant-custom-component==0.13.330
 ruff==0.15.12
 pre_commit==4.6.0
 yq==3.4.3

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -10,6 +10,8 @@ import pytest
 from custom_components.lockly.activity import ActivityBuffer, dedup_events
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from homeassistant.core import HomeAssistant
 
 
@@ -21,8 +23,12 @@ def store() -> AsyncMock:
 
 
 @pytest.fixture
-def buf(hass: HomeAssistant, store: AsyncMock) -> ActivityBuffer:
-    return ActivityBuffer(hass, store)
+async def buf(hass: HomeAssistant, store: AsyncMock) -> AsyncIterator[ActivityBuffer]:
+    buffer = ActivityBuffer(hass, store)
+    try:
+        yield buffer
+    finally:
+        await buffer.async_stop()
 
 
 @pytest.mark.asyncio
@@ -75,10 +81,13 @@ async def test_load_empty_store(buf: ActivityBuffer, store: AsyncMock) -> None:
 @pytest.mark.asyncio
 async def test_no_store(hass: HomeAssistant) -> None:
     buf = ActivityBuffer(hass, store=None)
-    buf.append({"lock": "Test"}, "lock")
-    assert len(buf.recent()) == 1
-    await buf.async_load()
-    assert len(buf.recent()) == 1
+    try:
+        buf.append({"lock": "Test"}, "lock")
+        assert len(buf.recent()) == 1
+        await buf.async_load()
+        assert len(buf.recent()) == 1
+    finally:
+        await buf.async_stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this changes

Lockly's `requirements.txt` was still pinned at HA `2026.3.1`. Most users — and the version this card was written against in the recent UI fixes — are already on 2026.5.x. Time to catch up.

Bumps:

- `homeassistant` 2026.3.1 → **2026.5.1**
- `pytest-homeassistant-custom-component` unpinned → **0.13.330** (the matching helper for HA 2026.5.x)
- `pytest` 9.0.0 → **9.0.3** (supersedes open Renovate PR #85 — that PR was failing the same teardown errors this fix resolves; closing it once this lands)
- `home-assistant-frontend` 20260429.3 → 20260429.4

## Why a code change was needed

The new helper enforces a stricter `verify_cleanup` teardown. Every test in `test_activity.py` was erroring because `ActivityBuffer`'s debounced save — a 1-second `async_call_later` that fires `_async_save` — was still pending when the test exited.

Fix: give `ActivityBuffer` an `async_stop()` that cancels the pending timer and flushes once if there's anything to write. Wire it into:

- `LocklyManager.async_stop` — so the production unload path also drains the buffer instead of orphaning a timer
- The `buf` test fixture (and the inline buffer in `test_no_store`) — so teardown cleans up

Flushing on stop is a small upside in production too: any events that landed in the debounce window get persisted on shutdown instead of dropped.

## Test plan

- [x] `python3 -m pytest tests/` → 92 passed, 0 errors
- [x] `pre-commit run --all-files` → all green (including pytest as a hook)
- [x] No production behavior change beyond a stop-time flush in `ActivityBuffer`