### PR TITLE
Install Claude Code in the devcontainer via scripts/setup

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -11,6 +11,8 @@ sudo npm install -g concurrently
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo BINDIR=/usr/local/bin bash
 pre-commit install
 
+curl -fsSL https://claude.ai/install.sh | bash
+
 # Disable xterm focus-reporting on shell startup. Some TUIs (notably tmux on
 # the host) leave it enabled, leaking ^[[O / ^[[I sequences into the prompt
 # on focus changes. Idempotent — only appends if not already present.


### PR DESCRIPTION
Add the Claude Code CLI to `scripts/setup` so a fresh devcontainer build has `claude` on PATH at `~/.local/bin/claude`.

Without this, dispatching a Claude session from the orchestrator into this container with `claude -p ...` fails with command-not-found, and the work has to fall back to running on the host (which is less aligned with the convention that toolchain operations run inside the container).

## What changed

- Appends `curl -fsSL https://claude.ai/install.sh | bash` to `scripts/setup`. This is the same line two other repos in the org use.

## Notes

- `~/.claude.json` is already bind-mounted by `.devcontainer/devcontainer.json`, so the installed CLI picks up the host session without re-authenticating.
- No `package.json` or `node_modules` needed; the installer drops a static binary into the user's `~/.local/bin`.
- Takes effect on the next container rebuild (no retroactive install).
