### PR TITLE
Remember the card filter you picked per browser

### DIFF
--- a/custom_components/lockly/frontend/lockly-activity-card.js
+++ b/custom_components/lockly/frontend/lockly-activity-card.js
@@ -13,6 +13,28 @@ const BANNER_STYLE = [
 // eslint-disable-next-line no-console
 console.info(`%c Lockly Activity Card ${CARD_VERSION} loaded`, BANNER_STYLE);
 
+// localStorage may throw in private browsing or when over quota; the card
+// must not break in either case, so reads return null and writes are silent.
+function readPref(key) {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (_) {
+    return null;
+  }
+}
+
+function writePref(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+function viewPrefKey(entryId) {
+  return `lockly:lockly-activity-card:${entryId || "default"}:view`;
+}
+
 const ACTION_ICONS = {
   unlock: "mdi:lock-open",
   lock: "mdi:lock",
@@ -94,6 +116,13 @@ function escapeHtml(str) {
 class LocklyActivityCard extends HTMLElement {
   setConfig(config) {
     this._config = { view: "recent", max_events: 5, lock_entities: [], ...config };
+    // The user's last in-UI choice on this browser wins over the YAML
+    // default; if they have never toggled, the YAML value (or the built-in
+    // "recent" default) is used.
+    const stored = readPref(viewPrefKey(this._config.entry_id));
+    if (stored === "recent" || stored === "per_lock") {
+      this._config.view = stored;
+    }
     if (!this._card) {
       this._card = document.createElement("ha-card");
       this.appendChild(this._card);
@@ -370,6 +399,7 @@ class LocklyActivityCard extends HTMLElement {
         const view = btn.getAttribute("data-view");
         if (view && view !== this._config.view) {
           this._config = { ...this._config, view };
+          writePref(viewPrefKey(this._config.entry_id), view);
           this._render();
         }
       });

--- a/custom_components/lockly/frontend/lockly-card.js
+++ b/custom_components/lockly/frontend/lockly-card.js
@@ -15,6 +15,28 @@ const BANNER_STYLE = [
 // eslint-disable-next-line no-console
 console.info(`%c Lockly Card ${CARD_VERSION} loaded`, BANNER_STYLE);
 
+// localStorage may throw in private browsing or when over quota; the card
+// must not break in either case, so reads return null and writes are silent.
+function readPref(key) {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (_) {
+    return null;
+  }
+}
+
+function writePref(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+function showDisabledPrefKey(entryId) {
+  return `lockly:lockly-card:${entryId || "default"}:showDisabled`;
+}
+
 class LocklyCard extends HTMLElement {
   setConfig(config) {
     this._config = { ...config };
@@ -22,7 +44,11 @@ class LocklyCard extends HTMLElement {
       this._config = { ...this._config, show_bulk_actions: true };
     }
     if (this._showDisabled === undefined) {
-      this._showDisabled = true;
+      const stored = readPref(showDisabledPrefKey(this._config.entry_id));
+      // Two valid strings: "all" (show every slot) and "enabled" (hide
+      // disabled). Anything else (including null) falls back to the default
+      // of true, which matches the pre-persistence behavior.
+      this._showDisabled = stored === "enabled" ? false : true;
     }
     if (!this._card) {
       this._card = document.createElement("ha-card");
@@ -431,6 +457,10 @@ class LocklyCard extends HTMLElement {
           return;
         }
         this._showDisabled = showDisabled;
+        writePref(
+          showDisabledPrefKey(this._config?.entry_id),
+          showDisabled ? "all" : "enabled"
+        );
         this._render();
       });
     });


### PR DESCRIPTION
Both cards have a top-of-card filter toggle that used to forget the user's choice on every page reload. This change makes those choices stick per browser, so picking "Enabled only" or "Per Lock" once means it's still there the next time the dashboard loads.

## What's persisted

- **`lockly-card`**: the "All" / "Enabled only" slot filter, stored under `lockly:lockly-card:<entry_id>:showDisabled`.
- **`lockly-activity-card`**: the "Recent" / "Per Lock" view toggle, stored under `lockly:lockly-activity-card:<entry_id>:view`.

`<entry_id>` is the Lockly config entry the card is bound to, so two Lockly instances on the same dashboard keep separate preferences. If `entry_id` is not yet set (the activity card's editor allows that briefly), the suffix `default` is used.

## Defaults and precedence

- If the user has never toggled, behavior is identical to before: the slot card defaults to "All", the activity card defaults to whatever the YAML `view:` field says (or "Recent" if unset).
- Once the user toggles in the UI on a given browser, that choice wins over the YAML default on subsequent renders from the same browser. Other browsers / users see their own remembered choice (or the YAML default if they have never toggled).
- `localStorage` access is wrapped in `try/catch`, so private browsing or quota-full storage degrades to "no persistence, defaults always" without breaking the card.

## Inspiration

Same `localStorage` pattern that `custom:expander-card` uses to remember its expanded state across reloads.

## Manual test plan

In a real Home Assistant dashboard:

1. Add a `lockly` card with `entry_id: <your entry>` and at least one disabled slot.
2. Confirm it opens on "All" (the existing default).
3. Click "Enabled only", then reload the page. Expect "Enabled only" still selected.
4. Open DevTools, inspect `localStorage`: a key like `lockly:lockly-card:<entry_id>:showDisabled` should be `enabled`.
5. Click "All", reload. Expect "All" selected; key now reads `all`.
6. Repeat for `lockly-activity-card` toggling between "Recent" and "Per Lock".
7. Open the same dashboard in a private/incognito window: cards should still render with the built-in default and not throw any console errors.

## What changed

- `custom_components/lockly/frontend/lockly-card.js`: added small `readPref`/`writePref` helpers, a `showDisabledPrefKey` builder, a localStorage read in `setConfig`, and a localStorage write in the click handler.
- `custom_components/lockly/frontend/lockly-activity-card.js`: the same shape, for the `view` toggle.

No Python changes; pytest suite (92 tests) still passes locally.
