### PR TITLE
Ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 .vscode
 coverage.xml
 .ruff_cache
+.claude/
 
 
 # Home Assistant configuration


### PR DESCRIPTION
Local Claude Code session state and `settings.local.json` live under `.claude/` and shouldn't be checked in. Adds it to `.gitignore` alongside the other tool caches.