### PR TITLE
Tighten the relative-time parens in the activity card

### DIFF
--- a/custom_components/lockly/frontend/lockly-activity-card.js
+++ b/custom_components/lockly/frontend/lockly-activity-card.js
@@ -479,8 +479,10 @@ class LocklyActivityCard extends HTMLElement {
           const unlockTitle = lastUnlock.timestamp
             ? absoluteTime(lastUnlock.timestamp)
             : "";
+          // Keep "(<time>)" inside one element so the surrounding flex layout
+          // does not insert a `gap` between the parens and the time text.
           const timeSuffix = unlockTime
-            ? ` (<span title="${escapeHtml(unlockTitle)}">${unlockTime}</span>)`
+            ? ` <span title="${escapeHtml(unlockTitle)}">(${unlockTime})</span>`
             : "";
           metaParts.push(
             `Last unlocked by ${escapeHtml(unlockWho)}${timeSuffix}`


### PR DESCRIPTION
Fixes a visual bug where the activity cards "Last unlocked by …" line rendered as `Last unlocked by Bunnywolf ( 3h ago )` instead of `Last unlocked by Bunnywolf (3h ago)`.

## Cause

`.la-meta` is a flex container with `gap: 6px`. The relative-time text was wrapped in a `<span>` (for its absolute-timestamp tooltip), and the parentheses sat outside the span as bare text. Flex layout treats each text run and element between flex children as a separate flex item, so the open paren, the time span, and the close paren each became a flex item, with `6px` of `gap` inserted between them.

## Fix

Move the parens inside the span. Now `(3h ago)` is one flex item, and the visual gaps disappear. The tooltip stays on the same span so hovering still shows the absolute timestamp.

## What changed

- `custom_components/lockly/frontend/lockly-activity-card.js`: two-line change in the "Last unlocked by …" branch of `_renderRow`, plus a short comment explaining why the parens belong inside the span.

## Verified

In the dev sandbox: triggered `UNLOCK` then `LOCK` on the simulated Back Door, refreshed the dashboard, the row now reads `Last unlocked by Slot 4 (Nm ago)` with tight parens. Visually matched against the previous behavior side by side.

`pytest tests/` (92 tests) still passes.