### PR TITLE
Stop double-escaping user names in the activity card

### DIFF
--- a/custom_components/lockly/frontend/lockly-activity-card.js
+++ b/custom_components/lockly/frontend/lockly-activity-card.js
@@ -437,7 +437,7 @@ class LocklyActivityCard extends HTMLElement {
     const label = ACTION_LABELS[action] || action;
     const lockName = escapeHtml(evt.lock || "Unknown lock");
     const rawLock = evt.lock || "";
-    const userName = evt.user_name ? escapeHtml(evt.user_name) : null;
+    const userName = evt.user_name || null;
     const slotId = evt.slot_id != null ? `Slot ${evt.slot_id}` : null;
     const who = userName || slotId || "";
     const source = evt.source ? SOURCE_LABELS[evt.source] || evt.source : "";


### PR DESCRIPTION
## Summary

Slot names containing ampersands or other HTML-special characters were being rendered in their escaped form in the activity card. A name like "Martha & Lina" showed up as "Martha &amp; Lina" because `escapeHtml` was being called twice on the path: once when assigning `evt.user_name` to the local `userName` variable, and again at the render site where the meta line is built.

Drop the pre-escape at assignment. The render site already escapes exactly once, which is correct, and it matches what the parallel `Slot {id}` branch was already doing (raw at assignment, escaped at render).

## Test plan

- [x] Existing tests pass (pre-commit pytest ran during commit)
- [x] In the dev environment, the activity card shows "Martha & Lina" instead of "Martha &amp; Lina"