### PR TITLE
Scope event entities to configured Lockly locks

### DIFF
--- a/custom_components/lockly/__init__.py
+++ b/custom_components/lockly/__init__.py
@@ -425,6 +425,117 @@ def _cleanup_legacy_entities(hass: HomeAssistant, entry: LocklyConfigEntry) -> N
             registry.async_remove(entity.entity_id)
 
 
+def _lock_event_slug(lock_name: str) -> str:
+    """Return the unique_id slug used by LocklyLockEvent for a lock_name."""
+    return lock_name.lower().replace(" ", "_").replace("-", "_")
+
+
+def _cleanup_stale_event_entities(
+    hass: HomeAssistant,
+    entry: LocklyConfigEntry,
+    lock_names: list[str],
+) -> None:
+    """Remove event entities for locks no longer in the configured set.
+
+    Older builds created `event.lockly_*` entities for any device that
+    happened to publish actions on the same Zigbee2MQTT base topic (e.g.
+    Control4 keypads sharing the broker). The discovery path is now scoped
+    to configured locks, but pre-existing stale entries must be cleaned up.
+    """
+    if not lock_names:
+        return
+    registry = er.async_get(hass)
+    expected = {_lock_event_slug(name) for name in lock_names}
+    prefix = f"{entry.entry_id}-lock-event-"
+    for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if entity.domain != "event":
+            continue
+        unique_id = entity.unique_id
+        if not unique_id.startswith(prefix):
+            continue
+        slug = unique_id[len(prefix) :]
+        if slug not in expected:
+            LOGGER.info(
+                "Removing stale Lockly event entity %s (lock %s not configured)",
+                entity.entity_id,
+                slug,
+            )
+            registry.async_remove(entity.entity_id)
+
+
+async def _handle_action_message(
+    manager: LocklyManager, msg: mqtt.ReceiveMessage
+) -> None:
+    """Handle raw action string from {topic}/+/action (slot confirmation)."""
+    topic = msg.topic
+    payload = msg.payload
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode()
+        except UnicodeDecodeError:
+            payload = payload.decode(errors="replace")
+    lock_name = topic[len(manager.mqtt_topic) + 1 : -len("/action")]
+    if not lock_name:
+        return
+    if lock_name not in manager.lock_names:
+        LOGGER.debug(
+            "Ignoring MQTT %s (lock %s not in configured set)", topic, lock_name
+        )
+        return
+    LOGGER.debug("MQTT %s: %s", topic, payload)
+    await manager.handle_mqtt_action(lock_name, str(payload))
+
+
+async def _handle_state_payload(
+    manager: LocklyManager, msg: mqtt.ReceiveMessage
+) -> None:
+    """Handle JSON state from {topic}/+ (actions, state changes)."""
+    topic = msg.topic
+    payload = msg.payload
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode()
+        except UnicodeDecodeError:
+            payload = payload.decode(errors="replace")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+    if not isinstance(payload, dict):
+        return
+    lock_name = topic[len(manager.mqtt_topic) + 1 :]
+    if not lock_name:
+        return
+    if lock_name not in manager.lock_names:
+        LOGGER.debug(
+            "Ignoring MQTT %s (lock %s not in configured set)", topic, lock_name
+        )
+        return
+    action = payload.get("action")
+    if action:
+        action_user = payload.get("action_user")
+        if isinstance(action_user, str) and action_user.isdigit():
+            action_user = int(action_user)
+        if not isinstance(action_user, int):
+            action_user = None
+        action_source_name = payload.get("action_source_name")
+        if not isinstance(action_source_name, str):
+            action_source_name = None
+        if action in ("pin_code_added", "pin_code_deleted"):
+            action_source_name = None
+        LOGGER.debug("MQTT %s action: %s", topic, action)
+        await manager.handle_mqtt_action(
+            lock_name,
+            str(action),
+            action_user=action_user,
+            action_source_name=action_source_name,
+            fire_lock_event=True,
+        )
+        return
+    await manager.handle_mqtt_state(lock_name, payload)
+
+
 async def _subscribe_mqtt(
     hass: HomeAssistant,
     entry: LocklyConfigEntry,
@@ -434,72 +545,21 @@ async def _subscribe_mqtt(
     if hass.data.get(f"{DOMAIN}_skip_mqtt", False):
         return
 
-    async def _handle_action_message(msg: mqtt.ReceiveMessage) -> None:
-        """Handle raw action string from {topic}/+/action (slot confirmation)."""
-        topic = msg.topic
-        payload = msg.payload
-        if isinstance(payload, bytes):
-            try:
-                payload = payload.decode()
-            except UnicodeDecodeError:
-                payload = payload.decode(errors="replace")
-        lock_name = topic[len(manager.mqtt_topic) + 1 : -len("/action")]
-        if not lock_name:
-            return
-        LOGGER.debug("MQTT %s: %s", topic, payload)
-        await manager.handle_mqtt_action(lock_name, str(payload))
+    async def _on_action(msg: mqtt.ReceiveMessage) -> None:
+        await _handle_action_message(manager, msg)
 
-    async def _handle_state_payload(msg: mqtt.ReceiveMessage) -> None:
-        """Handle JSON state from {topic}/+ (actions, state changes)."""
-        topic = msg.topic
-        payload = msg.payload
-        if isinstance(payload, bytes):
-            try:
-                payload = payload.decode()
-            except UnicodeDecodeError:
-                payload = payload.decode(errors="replace")
-        if isinstance(payload, str):
-            try:
-                payload = json.loads(payload)
-            except json.JSONDecodeError:
-                return
-        if not isinstance(payload, dict):
-            return
-        lock_name = topic[len(manager.mqtt_topic) + 1 :]
-        if not lock_name:
-            return
-        action = payload.get("action")
-        if action:
-            action_user = payload.get("action_user")
-            if isinstance(action_user, str) and action_user.isdigit():
-                action_user = int(action_user)
-            if not isinstance(action_user, int):
-                action_user = None
-            action_source_name = payload.get("action_source_name")
-            if not isinstance(action_source_name, str):
-                action_source_name = None
-            if action in ("pin_code_added", "pin_code_deleted"):
-                action_source_name = None
-            LOGGER.debug("MQTT %s action: %s", topic, action)
-            await manager.handle_mqtt_action(
-                lock_name,
-                str(action),
-                action_user=action_user,
-                action_source_name=action_source_name,
-                fire_lock_event=True,
-            )
-            return
-        await manager.handle_mqtt_state(lock_name, payload)
+    async def _on_state(msg: mqtt.ReceiveMessage) -> None:
+        await _handle_state_payload(manager, msg)
 
     unsub_action: Callable[[], None] = await mqtt.async_subscribe(
         hass,
         f"{manager.mqtt_topic}/+/action",
-        _handle_action_message,
+        _on_action,
     )
     unsub_state: Callable[[], None] = await mqtt.async_subscribe(
         hass,
         f"{manager.mqtt_topic}/+",
-        _handle_state_payload,
+        _on_state,
     )
     entry.runtime_data.subscriptions.extend([unsub_action, unsub_state])
 
@@ -513,6 +573,7 @@ async def async_setup_entry(
     manager = await _setup_entry_runtime(hass, entry)
     hass.data[DOMAIN][entry.entry_id] = entry.runtime_data
     _cleanup_legacy_entities(hass, entry)
+    _cleanup_stale_event_entities(hass, entry, manager.lock_names)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     await _subscribe_mqtt(hass, entry, manager)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.lockly import (
+    _handle_action_message,
+    _handle_state_payload,
+)
+from custom_components.lockly.const import (
+    CONF_ENDPOINT,
+    CONF_FIRST_SLOT,
+    CONF_LAST_SLOT,
+    CONF_LOCK_NAMES,
+    CONF_MQTT_TOPIC,
+    DEFAULT_ENDPOINT,
+    DEFAULT_FIRST_SLOT,
+    DEFAULT_LAST_SLOT,
+    DEFAULT_MQTT_TOPIC,
+    DOMAIN,
+)
 from custom_components.lockly.event import LocklyLockEvent
 from custom_components.lockly.logbook import EVENT_LOCKLY_LOCK_ACTIVITY
 
@@ -70,3 +91,207 @@ def test_fire_action_ignores_unknown_type(
         entity.fire_action("totally_bogus", {})
 
     mock_trigger.assert_not_called()
+
+
+async def _setup_entry_with_lock_names(
+    hass: HomeAssistant,
+    enable_custom_integrations: Any,
+    lock_names: list[str],
+    *,
+    entry_id: str | None = None,
+) -> MockConfigEntry:
+    """Set up a Lockly config entry whose lock_names resolves to the given list."""
+    _ = enable_custom_integrations
+    hass.data["lockly_skip_frontend"] = True
+    hass.data["lockly_skip_mqtt"] = True
+    hass.data["lockly_skip_worker"] = True
+    hass.data["lockly_skip_timeout"] = True
+    kwargs: dict[str, Any] = {
+        "domain": DOMAIN,
+        "title": "Lockly",
+        "data": {
+            CONF_NAME: "Lockly",
+            CONF_FIRST_SLOT: DEFAULT_FIRST_SLOT,
+            CONF_LAST_SLOT: DEFAULT_LAST_SLOT,
+            CONF_MQTT_TOPIC: DEFAULT_MQTT_TOPIC,
+            CONF_ENDPOINT: DEFAULT_ENDPOINT,
+            CONF_LOCK_NAMES: lock_names,
+        },
+    }
+    if entry_id is not None:
+        kwargs["entry_id"] = entry_id
+    entry = MockConfigEntry(**kwargs)
+    entry.add_to_hass(hass)
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    return entry
+
+
+@pytest.mark.enable_socket
+async def test_state_dispatch_ignores_unconfigured_lock(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """State-payload messages for non-configured locks must not reach the manager."""
+    entry = await _setup_entry_with_lock_names(
+        hass, enable_custom_integrations, ["Garden Upper Lock"]
+    )
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+    assert "Garden Upper Lock" in manager.lock_names
+
+    action_calls: list[tuple[tuple, dict]] = []
+    state_calls: list[tuple[tuple, dict]] = []
+
+    async def fake_action(*args: Any, **kwargs: Any) -> None:
+        action_calls.append((args, kwargs))
+
+    async def fake_state(*args: Any, **kwargs: Any) -> None:
+        state_calls.append((args, kwargs))
+
+    manager.handle_mqtt_action = fake_action
+    manager.handle_mqtt_state = fake_state
+
+    stale = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Control4 Keypad",
+        payload='{"action": "unlock", "action_user": 5}',
+    )
+    await _handle_state_payload(manager, stale)
+    assert action_calls == []
+    assert state_calls == []
+
+    valid = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Garden Upper Lock",
+        payload='{"action": "unlock"}',
+    )
+    await _handle_state_payload(manager, valid)
+    assert len(action_calls) == 1
+    args, kwargs = action_calls[0]
+    assert args[0] == "Garden Upper Lock"
+    assert args[1] == "unlock"
+    assert kwargs.get("fire_lock_event") is True
+
+
+@pytest.mark.enable_socket
+async def test_action_dispatch_ignores_unconfigured_lock(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """Action-topic messages for non-configured locks must not reach the manager."""
+    entry = await _setup_entry_with_lock_names(
+        hass, enable_custom_integrations, ["Garden Upper Lock"]
+    )
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+
+    calls: list[tuple[tuple, dict]] = []
+
+    async def tracker(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    manager.handle_mqtt_action = tracker
+
+    stale = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Control4 Keypad/action",
+        payload="unlock",
+    )
+    await _handle_action_message(manager, stale)
+    assert calls == []
+
+    valid = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Garden Upper Lock/action",
+        payload="unlock",
+    )
+    await _handle_action_message(manager, valid)
+    assert len(calls) == 1
+    args, _ = calls[0]
+    assert args[0] == "Garden Upper Lock"
+
+
+@pytest.mark.enable_socket
+async def test_setup_removes_stale_event_entities(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """Pre-existing event entities for unconfigured locks are removed at setup."""
+    _ = enable_custom_integrations
+    hass.data["lockly_skip_frontend"] = True
+    hass.data["lockly_skip_mqtt"] = True
+    hass.data["lockly_skip_worker"] = True
+    hass.data["lockly_skip_timeout"] = True
+
+    entry_id = "lockly_test_entry"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Lockly",
+        entry_id=entry_id,
+        data={
+            CONF_NAME: "Lockly",
+            CONF_FIRST_SLOT: DEFAULT_FIRST_SLOT,
+            CONF_LAST_SLOT: DEFAULT_LAST_SLOT,
+            CONF_MQTT_TOPIC: DEFAULT_MQTT_TOPIC,
+            CONF_ENDPOINT: DEFAULT_ENDPOINT,
+            CONF_LOCK_NAMES: ["Garden Upper Lock"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    stale = registry.async_get_or_create(
+        "event",
+        DOMAIN,
+        f"{entry_id}-lock-event-control4_keypad",
+        config_entry=entry,
+        suggested_object_id="lockly_control4_keypad",
+    )
+    keep = registry.async_get_or_create(
+        "event",
+        DOMAIN,
+        f"{entry_id}-lock-event-garden_upper_lock",
+        config_entry=entry,
+        suggested_object_id="lockly_garden_upper_lock",
+    )
+    assert registry.async_get(stale.entity_id) is not None
+    assert registry.async_get(keep.entity_id) is not None
+
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert registry.async_get(stale.entity_id) is None
+    assert registry.async_get(keep.entity_id) is not None
+
+
+@pytest.mark.enable_socket
+async def test_cleanup_skipped_when_no_lock_names_resolved(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """If lock_names is empty, cleanup must not nuke existing event entities."""
+    _ = enable_custom_integrations
+    hass.data["lockly_skip_frontend"] = True
+    hass.data["lockly_skip_mqtt"] = True
+    hass.data["lockly_skip_worker"] = True
+    hass.data["lockly_skip_timeout"] = True
+
+    entry_id = "lockly_empty_entry"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Lockly",
+        entry_id=entry_id,
+        data={
+            CONF_NAME: "Lockly",
+            CONF_FIRST_SLOT: DEFAULT_FIRST_SLOT,
+            CONF_LAST_SLOT: DEFAULT_LAST_SLOT,
+            CONF_MQTT_TOPIC: DEFAULT_MQTT_TOPIC,
+            CONF_ENDPOINT: DEFAULT_ENDPOINT,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    existing = registry.async_get_or_create(
+        "event",
+        DOMAIN,
+        f"{entry_id}-lock-event-garden_upper_lock",
+        config_entry=entry,
+        suggested_object_id="lockly_garden_upper_lock",
+    )
+
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert registry.async_get(existing.entity_id) is not None


### PR DESCRIPTION
Closes #100.

## Summary

The integration subscribes to `{base_topic}/+/action` and `{base_topic}/+` on the Zigbee2MQTT broker, which matches every device under that topic, not just Lockly locks. When a sibling device (e.g. a Control4 keypad) publishes an action, the integration's event platform was creating a permanent `event.lockly_*` entity for it. Stale entities sat in HA with state `unknown` forever.

Two-part fix:

1. **Filter at dispatch.** Both MQTT handlers now drop messages whose `lock_name` is not in `manager.lock_names`, so the manager and the event platform never see them. As part of the change the closures became module-level helpers taking `manager`, so they are unit-testable.

2. **One-shot cleanup of existing stale entries.** A new `_cleanup_stale_event_entities` runs from `async_setup_entry` (alongside the existing `_cleanup_legacy_entities` pass). It walks every event entity registered under the config entry, parses the lock_name slug out of its stored `unique_id`, and removes any whose slug is not in the configured set. The cleanup is a no-op when `lock_names` resolves empty so a transient resolution failure cannot wipe legitimate entities.

## Test plan

- [x] Four new tests in `tests/test_event.py` cover the filter on both MQTT handlers, the setup-time cleanup, and the empty-set safety guard
- [x] Full pytest suite passes (96 tests)
- [x] Ruff lint clean