### PR TITLE
Defer slot timeout status until every lock settles

### DIFF
--- a/custom_components/lockly/manager.py
+++ b/custom_components/lockly/manager.py
@@ -107,6 +107,7 @@ class LocklyManager:
         self._pending_by_lock: dict[str, list[int]] = {}
         self._pending_slots: dict[int, set[str]] = {}
         self._pending_lock_names: dict[int, list[str]] = {}
+        self._slot_outcomes: dict[int, dict[str, str]] = {}
         self._pending_actions: dict[tuple[int, str], dict[str, object]] = {}
         self._lock_queues: dict[str, asyncio.Queue[tuple[int, dict]]] = {}
         self._lock_workers: dict[str, asyncio.Task] = {}
@@ -628,6 +629,7 @@ class LocklyManager:
         pending_locks = set(job.lock_names)
         self._pending_slots[job.slot_id] = pending_locks
         self._pending_lock_names[job.slot_id] = list(job.lock_names)
+        self._slot_outcomes[job.slot_id] = {}
         for lock_name in job.lock_names:
             self._pending_by_lock.setdefault(lock_name, []).append(job.slot_id)
             payload = self._build_slot_payload(
@@ -669,6 +671,7 @@ class LocklyManager:
         await self.update_slot(slot_id, busy=False, status="")
         self._pending_slots.pop(slot_id, None)
         self._pending_lock_names.pop(slot_id, None)
+        self._slot_outcomes.pop(slot_id, None)
         for lock_name in lock_names:
             self._pending_actions.pop((slot_id, lock_name), None)
         await self._finalize_slot_completion(slot_id)
@@ -705,6 +708,7 @@ class LocklyManager:
             if handle is not None:
                 handle.cancel()
         self._pending_actions.clear()
+        self._slot_outcomes.clear()
         if self._activity is not None:
             await self._activity.async_stop()
 
@@ -804,11 +808,13 @@ class LocklyManager:
         pending_locks = self._pending_slots.get(slot_id)
         if pending_locks:
             pending_locks.discard(lock_name)
+        outcomes = self._slot_outcomes.get(slot_id)
+        if outcomes is not None:
+            outcomes[lock_name] = "timeout"
         if slot_id not in self._coordinator.data:
             return
         await self.update_slot(
             slot_id,
-            status="timeout",
             last_response={
                 "lock": lock_name,
                 "status": "timeout",
@@ -823,11 +829,7 @@ class LocklyManager:
             attempts + 1,
         )
         if pending_locks is not None and not pending_locks:
-            self._pending_slots.pop(slot_id, None)
-            self._pending_lock_names.pop(slot_id, None)
-            self._slot_publish_started.discard(slot_id)
-            await self.update_slot(slot_id, busy=False, status="timeout")
-            await self._finalize_slot_completion(slot_id)
+            await self._finalize_slot_after_settle(slot_id)
 
     async def _publish_lock(self, lock_name: str, payload: dict) -> None:
         """Publish a Zigbee2MQTT per-lock set command."""
@@ -1033,6 +1035,9 @@ class LocklyManager:
             status = "enabled"
         else:
             status = "unknown"
+        outcomes = self._slot_outcomes.get(slot_id)
+        if outcomes is not None:
+            outcomes[lock_name] = status
         LOGGER.debug(
             "Lock action for slot %s on %s: %s",
             slot_id,
@@ -1048,11 +1053,25 @@ class LocklyManager:
             last_response_ts=time.time(),
         )
         if pending_locks is not None and not pending_locks:
-            self._pending_slots.pop(slot_id, None)
-            self._slot_publish_started.discard(slot_id)
-            await self.update_slot(slot_id, busy=False, status="")
-            self._pending_lock_names.pop(slot_id, None)
-            await self._finalize_slot_completion(slot_id)
+            await self._finalize_slot_after_settle(slot_id)
+
+    async def _finalize_slot_after_settle(self, slot_id: int) -> None:
+        """Finalize a slot once every lock has settled.
+
+        Derives the overall status from per-lock outcomes so a single timeout
+        among otherwise successful locks does not flip the slot to "timeout".
+        """
+        self._pending_slots.pop(slot_id, None)
+        self._pending_lock_names.pop(slot_id, None)
+        self._slot_publish_started.discard(slot_id)
+        outcomes = self._slot_outcomes.pop(slot_id, None) or {}
+        if outcomes and all(value == "timeout" for value in outcomes.values()):
+            final_status = "timeout"
+        else:
+            final_status = ""
+        if slot_id in self._coordinator.data:
+            await self.update_slot(slot_id, busy=False, status=final_status)
+        await self._finalize_slot_completion(slot_id)
 
     async def _finalize_slot_completion(self, slot_id: int) -> None:
         """Resolve completion futures and remove slots if requested."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -618,6 +618,139 @@ async def test_action_timeout_retries_then_times_out(
     }
 
 
+async def _apply_to_two_locks(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Trigger apply_slot against both garden locks and pump the loop."""
+    hass.states.async_set(
+        "lock.garden_lower_lock",
+        "locked",
+        {"friendly_name": "Garden Lower Lock"},
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "apply_slot",
+        {
+            "entry_id": entry.entry_id,
+            "slot": 1,
+            "lock_entities": [
+                "lock.garden_upper_lock",
+                "lock.garden_lower_lock",
+            ],
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def _simulate_timeout(
+    hass: HomeAssistant, manager: Any, slot_id: int, lock_name: str
+) -> None:
+    """Cancel a lock's scheduled timer and invoke the timeout handler."""
+    manager._cancel_action_timer(slot_id, lock_name)  # noqa: SLF001
+    await manager._handle_action_timeout(slot_id, lock_name)  # noqa: SLF001
+    await hass.async_block_till_done()
+
+
+@pytest.mark.enable_socket
+async def test_multi_lock_partial_timeout_keeps_status_clear(
+    hass: HomeAssistant, enable_custom_integrations: Any, monkeypatch: Any
+) -> None:
+    """One lock timing out while others succeed must not flip slot to timeout."""
+    monkeypatch.setattr(lockly_manager, "DEFAULT_ACTION_TIMEOUT", 100)
+    monkeypatch.setattr(lockly_manager, "MAX_ACTION_RETRIES", 0)
+    entry = await _setup_entry(
+        hass, enable_custom_integrations, skip_timeout=False, skip_worker=True
+    )
+    async_mock_service(hass, "mqtt", "publish")
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+    await manager.add_slot()
+    await manager.update_slot(1, name="One", pin="1111", enabled=True)
+
+    await _apply_to_two_locks(hass, entry)
+
+    await manager.handle_mqtt_action(
+        "Garden Upper Lock", "pin_code_added", action_user=1
+    )
+    await hass.async_block_till_done()
+
+    slot = manager.coordinator.data[1]
+    assert slot.status == "updating"
+    assert slot.busy is True
+
+    await _simulate_timeout(hass, manager, 1, "Garden Lower Lock")
+
+    assert slot.status == ""
+    assert slot.busy is False
+    assert slot.last_response == {
+        "lock": "Garden Lower Lock",
+        "status": "timeout",
+        "attempts": 1,
+    }
+
+
+@pytest.mark.enable_socket
+async def test_multi_lock_all_timeout_sets_status_timeout(
+    hass: HomeAssistant, enable_custom_integrations: Any, monkeypatch: Any
+) -> None:
+    """When every lock times out, the slot finalizes as timeout."""
+    monkeypatch.setattr(lockly_manager, "DEFAULT_ACTION_TIMEOUT", 100)
+    monkeypatch.setattr(lockly_manager, "MAX_ACTION_RETRIES", 0)
+    entry = await _setup_entry(
+        hass, enable_custom_integrations, skip_timeout=False, skip_worker=True
+    )
+    async_mock_service(hass, "mqtt", "publish")
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+    await manager.add_slot()
+    await manager.update_slot(1, name="One", pin="1111", enabled=True)
+
+    await _apply_to_two_locks(hass, entry)
+
+    await _simulate_timeout(hass, manager, 1, "Garden Upper Lock")
+
+    slot = manager.coordinator.data[1]
+    assert slot.status == "updating"
+    assert slot.busy is True
+
+    await _simulate_timeout(hass, manager, 1, "Garden Lower Lock")
+
+    assert slot.status == "timeout"
+    assert slot.busy is False
+
+
+@pytest.mark.enable_socket
+async def test_multi_lock_status_stays_updating_when_one_times_out(
+    hass: HomeAssistant, enable_custom_integrations: Any, monkeypatch: Any
+) -> None:
+    """Slot must not flash to timeout while other locks are still pending."""
+    monkeypatch.setattr(lockly_manager, "DEFAULT_ACTION_TIMEOUT", 100)
+    monkeypatch.setattr(lockly_manager, "MAX_ACTION_RETRIES", 0)
+    entry = await _setup_entry(
+        hass, enable_custom_integrations, skip_timeout=False, skip_worker=True
+    )
+    async_mock_service(hass, "mqtt", "publish")
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+    await manager.add_slot()
+    await manager.update_slot(1, name="One", pin="1111", enabled=True)
+
+    await _apply_to_two_locks(hass, entry)
+
+    slot = manager.coordinator.data[1]
+    assert slot.status == "updating"
+    assert slot.busy is True
+
+    await _simulate_timeout(hass, manager, 1, "Garden Upper Lock")
+
+    assert slot.status == "updating"
+    assert slot.busy is True
+
+    await manager.handle_mqtt_action(
+        "Garden Lower Lock", "pin_code_added", action_user=1
+    )
+    await hass.async_block_till_done()
+
+    assert slot.status == ""
+    assert slot.busy is False
+
+
 @pytest.mark.enable_socket
 async def test_lock_queue_preserves_order(
     hass: HomeAssistant, enable_custom_integrations: Any


### PR DESCRIPTION
## Summary

When a slot is applied to multiple locks and one of them hits the retry cap, the slot's status was flipping to `"timeout"` immediately, even if other locks had already succeeded or were still trying. The user then sees a confusing "Timeout" badge on a slot that mostly succeeded, clicks Apply again to retry, and the resulting publishes pile up "PIN added" entries in the activity log.

The fix:

* Track per-lock outcomes in the manager (`self._slot_outcomes[slot_id] = {lock_name: "enabled" | "available" | "unknown" | "timeout"}`).
* Stop writing `status="timeout"` mid-flight in `_handle_action_timeout`. The slot stays `"updating"` while any lock is still pending.
* Extract a shared `_finalize_slot_after_settle` helper that runs only when the last lock settles. It derives the overall status from the outcomes map: `"timeout"` only if *every* lock timed out, `""` if any succeeded.
* Clear the outcomes dict in `_finalize_skip_timeout` and `async_stop` so state does not leak across applies or test runs.

This is the minimal-fix version; a more nuanced per-lock UI status (e.g. "applied to 3 of 5") is deliberately out of scope for this change.

## Test plan

- [x] New test: 1 lock times out, 1 lock succeeds. Slot ends `status=""`, `busy=False`, `last_response` reflects the timeout.
- [x] New test: all locks time out. Slot ends `status="timeout"`, `busy=False`.
- [x] New test: while one lock has timed out and the other has not, the slot's `status` stays `"updating"` and does not flash to `"timeout"`.
- [x] Existing single-lock timeout test still passes (single-lock semantics unchanged).
- [x] Full pytest suite green; ruff clean.
- [ ] Manual: run a multi-lock apply in prod where one lock is reachable and one is offline, verify the slot does not flip to Timeout while the good lock is still confirming.