### PR TITLE
Scope MQTT dispatch filter to HA lock.* entities

### DIFF
--- a/custom_components/lockly/__init__.py
+++ b/custom_components/lockly/__init__.py
@@ -430,22 +430,40 @@ def _lock_event_slug(lock_name: str) -> str:
     return lock_name.lower().replace(" ", "_").replace("-", "_")
 
 
+def _known_lock_names(hass: HomeAssistant) -> set[str]:
+    """Return friendly_names of every lock.* entity currently in HA.
+
+    Lockly intentionally pulls this from the live state machine rather
+    than the config entry, so users who specify locks only at the
+    Lovelace card level (or via dynamic groups) are not silently
+    filtered out. Non-lock devices that publish on the same Zigbee2MQTT
+    base topic are excluded by domain, which is the original goal of
+    the filter introduced in PR #103.
+    """
+    names: set[str] = set()
+    for state in hass.states.async_all("lock"):
+        friendly = state.attributes.get("friendly_name")
+        if isinstance(friendly, str) and friendly:
+            names.add(friendly)
+    return names
+
+
 def _cleanup_stale_event_entities(
     hass: HomeAssistant,
     entry: LocklyConfigEntry,
-    lock_names: list[str],
 ) -> None:
-    """Remove event entities for locks no longer in the configured set.
+    """Remove event entities for locks no longer known to HA.
 
     Older builds created `event.lockly_*` entities for any device that
     happened to publish actions on the same Zigbee2MQTT base topic (e.g.
-    Control4 keypads sharing the broker). The discovery path is now scoped
-    to configured locks, but pre-existing stale entries must be cleaned up.
+    Control4 keypads sharing the broker). The discovery path now scopes
+    to currently registered `lock.*` entities, but pre-existing stale
+    entries must be cleaned up.
     """
-    if not lock_names:
+    known = {_lock_event_slug(name) for name in _known_lock_names(hass)}
+    if not known:
         return
     registry = er.async_get(hass)
-    expected = {_lock_event_slug(name) for name in lock_names}
     prefix = f"{entry.entry_id}-lock-event-"
     for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
         if entity.domain != "event":
@@ -454,9 +472,9 @@ def _cleanup_stale_event_entities(
         if not unique_id.startswith(prefix):
             continue
         slug = unique_id[len(prefix) :]
-        if slug not in expected:
+        if slug not in known:
             LOGGER.info(
-                "Removing stale Lockly event entity %s (lock %s not configured)",
+                "Removing stale Lockly event entity %s (lock %s not a known HA lock)",
                 entity.entity_id,
                 slug,
             )
@@ -477,9 +495,9 @@ async def _handle_action_message(
     lock_name = topic[len(manager.mqtt_topic) + 1 : -len("/action")]
     if not lock_name:
         return
-    if lock_name not in manager.lock_names:
+    if lock_name not in _known_lock_names(manager.hass):
         LOGGER.debug(
-            "Ignoring MQTT %s (lock %s not in configured set)", topic, lock_name
+            "Ignoring MQTT %s (lock %s not a known HA lock entity)", topic, lock_name
         )
         return
     LOGGER.debug("MQTT %s: %s", topic, payload)
@@ -507,9 +525,9 @@ async def _handle_state_payload(
     lock_name = topic[len(manager.mqtt_topic) + 1 :]
     if not lock_name:
         return
-    if lock_name not in manager.lock_names:
+    if lock_name not in _known_lock_names(manager.hass):
         LOGGER.debug(
-            "Ignoring MQTT %s (lock %s not in configured set)", topic, lock_name
+            "Ignoring MQTT %s (lock %s not a known HA lock entity)", topic, lock_name
         )
         return
     action = payload.get("action")
@@ -573,7 +591,7 @@ async def async_setup_entry(
     manager = await _setup_entry_runtime(hass, entry)
     hass.data[DOMAIN][entry.entry_id] = entry.runtime_data
     _cleanup_legacy_entities(hass, entry)
-    _cleanup_stale_event_entities(hass, entry, manager.lock_names)
+    _cleanup_stale_event_entities(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     await _subscribe_mqtt(hass, entry, manager)

--- a/custom_components/lockly/manager.py
+++ b/custom_components/lockly/manager.py
@@ -121,6 +121,11 @@ class LocklyManager:
         self._activity = activity
 
     @property
+    def hass(self) -> HomeAssistant:
+        """Return the HomeAssistant instance bound to this manager."""
+        return self._hass
+
+    @property
     def group_entity_id(self) -> str | None:
         """Return the configured lock group entity id."""
         data = self._entry.options or self._entry.data

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -93,19 +93,38 @@ def test_fire_action_ignores_unknown_type(
     mock_trigger.assert_not_called()
 
 
+def _register_lock_state(hass: HomeAssistant, lock_name: str) -> None:
+    """Register a `lock.*` entity in the state machine with the given friendly_name."""
+    slug = lock_name.lower().replace(" ", "_").replace("-", "_")
+    hass.states.async_set(
+        f"lock.{slug}",
+        "locked",
+        {"friendly_name": lock_name},
+    )
+
+
 async def _setup_entry_with_lock_names(
     hass: HomeAssistant,
     enable_custom_integrations: Any,
     lock_names: list[str],
     *,
     entry_id: str | None = None,
+    register_states: bool = True,
 ) -> MockConfigEntry:
-    """Set up a Lockly config entry whose lock_names resolves to the given list."""
+    """Set up a Lockly config entry whose lock_names resolves to the given list.
+
+    By default this also registers matching `lock.*` entities in the state
+    machine; the dispatch filter now derives its set of valid lock names
+    from the state machine rather than from config.
+    """
     _ = enable_custom_integrations
     hass.data["lockly_skip_frontend"] = True
     hass.data["lockly_skip_mqtt"] = True
     hass.data["lockly_skip_worker"] = True
     hass.data["lockly_skip_timeout"] = True
+    if register_states:
+        for name in lock_names:
+            _register_lock_state(hass, name)
     kwargs: dict[str, Any] = {
         "domain": DOMAIN,
         "title": "Lockly",
@@ -230,6 +249,7 @@ async def test_setup_removes_stale_event_entities(
         },
     )
     entry.add_to_hass(hass)
+    _register_lock_state(hass, "Garden Upper Lock")
 
     registry = er.async_get(hass)
     stale = registry.async_get_or_create(
@@ -295,3 +315,109 @@ async def test_cleanup_skipped_when_no_lock_names_resolved(
     await hass.async_block_till_done()
 
     assert registry.async_get(existing.entity_id) is not None
+
+
+@pytest.mark.enable_socket
+async def test_state_dispatch_allows_lock_present_only_in_state_machine(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """Dispatch when the only signal is a `lock.*` entity in the state machine."""
+    _ = enable_custom_integrations
+    hass.data["lockly_skip_frontend"] = True
+    hass.data["lockly_skip_mqtt"] = True
+    hass.data["lockly_skip_worker"] = True
+    hass.data["lockly_skip_timeout"] = True
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Lockly",
+        data={
+            CONF_NAME: "Lockly",
+            CONF_FIRST_SLOT: DEFAULT_FIRST_SLOT,
+            CONF_LAST_SLOT: DEFAULT_LAST_SLOT,
+            CONF_MQTT_TOPIC: DEFAULT_MQTT_TOPIC,
+            CONF_ENDPOINT: DEFAULT_ENDPOINT,
+        },
+    )
+    entry.add_to_hass(hass)
+    _register_lock_state(hass, "Front Door Lock")
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+    assert manager.lock_names == []
+
+    action_calls: list[tuple[tuple, dict]] = []
+
+    async def fake_action(*args: Any, **kwargs: Any) -> None:
+        action_calls.append((args, kwargs))
+
+    manager.handle_mqtt_action = fake_action
+
+    valid = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Front Door Lock",
+        payload='{"action": "unlock"}',
+    )
+    await _handle_state_payload(manager, valid)
+    assert len(action_calls) == 1
+    args, kwargs = action_calls[0]
+    assert args[0] == "Front Door Lock"
+    assert args[1] == "unlock"
+    assert kwargs.get("fire_lock_event") is True
+
+    stranger = SimpleNamespace(
+        topic=f"{DEFAULT_MQTT_TOPIC}/Entry Keypad",
+        payload='{"action": "unlock"}',
+    )
+    await _handle_state_payload(manager, stranger)
+    assert len(action_calls) == 1
+
+
+@pytest.mark.enable_socket
+async def test_cleanup_uses_ha_lock_registry_for_known_set(
+    hass: HomeAssistant, enable_custom_integrations: Any
+) -> None:
+    """Cleanup keeps entities matching a current `lock.*` and drops others."""
+    _ = enable_custom_integrations
+    hass.data["lockly_skip_frontend"] = True
+    hass.data["lockly_skip_mqtt"] = True
+    hass.data["lockly_skip_worker"] = True
+    hass.data["lockly_skip_timeout"] = True
+
+    entry_id = "lockly_registry_cleanup"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Lockly",
+        entry_id=entry_id,
+        data={
+            CONF_NAME: "Lockly",
+            CONF_FIRST_SLOT: DEFAULT_FIRST_SLOT,
+            CONF_LAST_SLOT: DEFAULT_LAST_SLOT,
+            CONF_MQTT_TOPIC: DEFAULT_MQTT_TOPIC,
+            CONF_ENDPOINT: DEFAULT_ENDPOINT,
+        },
+    )
+    entry.add_to_hass(hass)
+    _register_lock_state(hass, "Front Door Lock")
+
+    registry = er.async_get(hass)
+    keep = registry.async_get_or_create(
+        "event",
+        DOMAIN,
+        f"{entry_id}-lock-event-front_door_lock",
+        config_entry=entry,
+        suggested_object_id="lockly_front_door_lock",
+    )
+    stale = registry.async_get_or_create(
+        "event",
+        DOMAIN,
+        f"{entry_id}-lock-event-control4_keypad",
+        config_entry=entry,
+        suggested_object_id="lockly_control4_keypad",
+    )
+
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert registry.async_get(keep.entity_id) is not None
+    assert registry.async_get(stale.entity_id) is None


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #103. The MQTT dispatch filter rejected every message when the config entry had no `CONF_LOCK_NAMES`, no `CONF_LOCK_ENTITIES`, and no `group_entity_id`, because `manager.lock_names` returned `[]` and the filter checked `lock_name not in manager.lock_names`. Setups that specify locks only at the Lovelace card level (`lock_entities: lock.all_locks` in the card YAML) hit exactly this case: publishes went out, but lock responses were silently dropped, so slot completions never fired, the activity buffer never updated, and event entities stopped receiving actions.

The fix derives the valid-lock set from the live HA state machine instead of the config entry. A new `_known_lock_names(hass)` helper returns the friendly_names of every `lock.*` entity HA knows about. The dispatch handlers and the stale-entity cleanup pass all use this helper. Control4 keypads (and other non-lock devices on the same Z2M base topic) continue to be filtered out, since they are not `lock.*` entities; the goal of #103 (issue #100) is preserved without the false-positive on card-level configs.

`manager.lock_names`, `apply_slot`, and the publish path are unchanged.

## Test plan

- [x] New test: config entry has no `CONF_LOCK_NAMES` / `CONF_LOCK_ENTITIES` / group, state machine has a `lock.*` entity with friendly_name `"Front Door Lock"`; a state-payload action for `Front Door Lock` is dispatched (filter passes).
- [x] New test: same setup, message for `"Entry Keypad"` (no matching `lock.*` entity) is filtered.
- [x] New test: `_cleanup_stale_event_entities` keeps entries whose slug matches a current `lock.*` friendly_name, removes those that do not.
- [x] Existing PR #103 dispatch-filter tests updated to register matching `lock.*` states; all pass.
- [x] Full pytest suite green (101 tests), ruff clean.
- [ ] Manual: bharat to pin HACS to this PR's merge SHA in prod, repeat the multi-lock apply, confirm activity card refreshes and slot status settles.