### PR TITLE
Calm noisy retry storm on slow Lockly locks

### DIFF
--- a/custom_components/lockly/activity.py
+++ b/custom_components/lockly/activity.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 MAX_EVENTS = 500
 DEDUP_WINDOW_SECONDS = 5
 DEDUP_WINDOW_PHYSICAL = 60
+DEDUP_WINDOW_PIN_CODE = 60
 
 _PHYSICAL_TO_BASE: dict[str, str] = {
     "manual_lock": "lock",
@@ -28,14 +29,10 @@ _DELIBERATE_TO_BASE: dict[str, str] = {
 _AUTOMATION_SOURCES: set[str] = {"rf", "remote"}
 
 
-def _within_window(
-    prev: dict[str, object],
-    curr: dict[str, object],
-    window: float = DEDUP_WINDOW_SECONDS,
+def _timestamps_within(
+    prev: dict[str, object], curr: dict[str, object], window: float
 ) -> bool:
-    """Check whether two events are for the same lock within *window* seconds."""
-    if prev.get("lock") != curr.get("lock"):
-        return False
+    """Return True when prev and curr have parseable timestamps within *window*."""
     prev_ts = prev.get("timestamp")
     curr_ts = curr.get("timestamp")
     if not isinstance(prev_ts, str) or not isinstance(curr_ts, str):
@@ -46,6 +43,17 @@ def _within_window(
     except (ValueError, TypeError):
         return False
     return abs((curr_time - prev_time).total_seconds()) <= window
+
+
+def _within_window(
+    prev: dict[str, object],
+    curr: dict[str, object],
+    window: float = DEDUP_WINDOW_SECONDS,
+) -> bool:
+    """Check whether two events are for the same lock within *window* seconds."""
+    if prev.get("lock") != curr.get("lock"):
+        return False
+    return _timestamps_within(prev, curr, window)
 
 
 def _merge_keep_first(
@@ -65,12 +73,30 @@ def _try_merge(
 ) -> dict[str, object] | None:
     """Merge two adjacent events if they are redundant.
 
-    Cases 1-3 handle firmware echoes and exact repeats within a narrow
-    window.  Case 4 handles deliberate physical actions (one_touch_lock)
-    followed by a redundant automation lock within a wider window.
+    Case 0 handles slow pin_code_added / pin_code_deleted echoes on the
+    same lock + slot within a wider window.  Cases 1-3 handle firmware
+    echoes and exact repeats within a narrow window.  Case 4 handles
+    deliberate physical actions (one_touch_lock) followed by a redundant
+    automation lock within a wider window.
     """
     prev_action = prev.get("action")
     curr_action = curr.get("action")
+
+    # Case 0: pin_code_added / pin_code_deleted echo on the same lock+slot
+    # within the wider PIN-code window. Lockly firmware can take 10s+ to ack
+    # a slot update, so the manager often retries before the first ack lands;
+    # the lock then echoes each retry. Collapse all of these into one entry
+    # at display time. Requires same lock AND same slot, so an unrelated
+    # action on the same lock does not get swallowed.
+    if (
+        prev_action == curr_action
+        and curr_action in ("pin_code_added", "pin_code_deleted")
+        and prev.get("lock") == curr.get("lock")
+        and prev.get("slot_id") is not None
+        and prev.get("slot_id") == curr.get("slot_id")
+        and _timestamps_within(prev, curr, DEDUP_WINDOW_PIN_CODE)
+    ):
+        return _merge_keep_first(prev, curr)
 
     if _within_window(prev, curr):
         # Case 1: curr is firmware echo, prev is the base action

--- a/custom_components/lockly/manager.py
+++ b/custom_components/lockly/manager.py
@@ -83,7 +83,7 @@ SLOT_NOT_FOUND = "slot_not_found"
 NO_LOCKS_CONFIGURED = "no_locks_configured"
 INVALID_PIN = "invalid_pin"
 INVALID_SLOT = "invalid_slot"
-DEFAULT_ACTION_TIMEOUT = 10
+DEFAULT_ACTION_TIMEOUT = 30
 MAX_ACTION_RETRIES = 3
 
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -617,3 +617,114 @@ def test_dedup_events_physical_base_pair() -> None:
     assert len(result) == 1
     assert result[0]["action"] == "lock"
     assert result[0]["source"] == "automation"
+
+
+# --- pin_code_added / pin_code_deleted wider dedup (case 0) ---
+
+
+def test_dedup_pin_code_added_same_slot_within_window() -> None:
+    """Two pin_code_added for same lock+slot, 30s apart, merge into one."""
+    events = [
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "user_name": "Alice",
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "user_name": "Alice",
+            "timestamp": "2026-01-01T00:00:30+00:00",
+        },
+    ]
+    result = dedup_events(events)
+    assert len(result) == 1
+    assert result[0]["timestamp"] == "2026-01-01T00:00:00+00:00"
+    assert result[0]["user_name"] == "Alice"
+    assert result[0]["slot_id"] == 7
+    assert result[0]["action"] == "pin_code_added"
+
+
+def test_dedup_pin_code_added_outside_window_not_merged() -> None:
+    """Two pin_code_added 90s apart exceed the PIN window and stay separate."""
+    events = [
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:01:30+00:00",
+        },
+    ]
+    result = dedup_events(events)
+    assert len(result) == 2
+
+
+def test_dedup_pin_code_added_different_slot_not_merged() -> None:
+    """Same lock but different slot_id is not merged."""
+    events = [
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 8,
+            "timestamp": "2026-01-01T00:00:10+00:00",
+        },
+    ]
+    result = dedup_events(events)
+    assert len(result) == 2
+
+
+def test_dedup_pin_code_added_different_lock_not_merged() -> None:
+    """Same slot_id on different locks is not merged."""
+    events = [
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "lock": "Front Door",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:10+00:00",
+        },
+    ]
+    result = dedup_events(events)
+    assert len(result) == 2
+
+
+def test_dedup_pin_code_added_then_unlock_not_merged() -> None:
+    """pin_code_added followed by unlock is not collapsed."""
+    events = [
+        {
+            "lock": "Garage Entry",
+            "action": "pin_code_added",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "lock": "Garage Entry",
+            "action": "unlock",
+            "slot_id": 7,
+            "timestamp": "2026-01-01T00:00:10+00:00",
+        },
+    ]
+    result = dedup_events(events)
+    assert len(result) == 2
+    assert result[0]["action"] == "pin_code_added"
+    assert result[1]["action"] == "unlock"


### PR DESCRIPTION
## Summary

On a prod install with one Lockly lock that takes ~30-40 seconds to ack a `pin_code_added` or `pin_code_deleted`, the integration's 10-second retry timer was firing 3-4 times before the lock's first ack arrived. Each retry republished the same payload; the lock then emitted one `pin_code_added` (plus a firmware echo) for each publish. The activity card surfaced all of them, spread over a minute, which looked like the integration was malfunctioning when in fact the lock was just slow.

Two complementary changes:

- **A: longer retry timeout.** `DEFAULT_ACTION_TIMEOUT` goes from 10s to 30s. Fewer retries fire before the lock has a chance to ack, so the upstream chatter is dramatically reduced. The trade-off is that a genuinely-dead lock now takes ~120s instead of ~40s to declare timeout, which is acceptable for this integration's use case.

- **C: wider display-time dedup window for PIN-code actions.** Added a new case to `_try_merge` in `activity.py` that collapses `pin_code_added` / `pin_code_deleted` echoes on the same lock + same slot within 60 seconds. Other action types continue to use the existing 5-second window. Slot-id and lock equality are both required so unrelated actions on the same lock are never accidentally merged.

These compose: A removes most of the retry-driven duplicates at the source; C cleans up anything that still gets through. Option B (drain the in-flight publish queue when an ack arrives) was considered and deferred; A+C is expected to remove the user-visible symptom without the extra coordination code.

## Test plan

- [x] 5 new dedup tests in `tests/test_activity.py`: in-window merge preserves earlier timestamp / user_name / slot_id, 90s outside window does not merge, different slot does not merge, different lock does not merge, PIN-then-unlock is not spuriously merged.
- [x] Existing dedup tests (cases 1-4) unchanged and still pass.
- [x] Existing retry tests use `monkeypatch.setattr` against the constant, so no test updates were needed for the timeout bump.
- [x] Full pytest suite green (106 tests), ruff clean, pre-commit hooks pass.
- [ ] Manual: bharat to pin HACS to this PR's merge SHA, run a disable+enable on slot 17 against the slow lock, verify the activity card collapses the retry-echoes into one entry per (lock, slot, action).