### PR TITLE
Keep in-flight slots visible under the Enabled-only filter

### DIFF
--- a/custom_components/lockly/frontend/lockly-card.js
+++ b/custom_components/lockly/frontend/lockly-card.js
@@ -215,7 +215,12 @@ class LocklyCard extends HTMLElement {
     const showDisabled = this._showDisabled !== false;
     const slots = showDisabled
       ? allSlots
-      : allSlots.filter((slot) => slot.enabled);
+      : allSlots.filter(
+          (slot) =>
+            slot.enabled ||
+            slot.status === "updating" ||
+            slot.status === "queued",
+        );
     this._card.innerHTML = `
       <style>
         .header {


### PR DESCRIPTION
## Summary

When the slot card was set to **Enabled only** and you disabled a slot, the row vanished the instant the disable was queued. The filter read `slot.enabled`, and the manager flips that field as soon as the apply starts, before the MQTT round-trip resolves. You lost sight of the slot while it was in the Updating state and had no way to tell whether the lock had acked, timed out, or was still working.

The fix keeps a slot in the Enabled-only view if its `status` is `"updating"` or `"queued"`, regardless of `slot.enabled`. Either it is about to become enabled, or it just stopped being enabled and is mid-transition; either way you want to watch it resolve.

Terminal states (`""` and `"timeout"`) are unaffected: once the transition finishes, the slot disappears from the Enabled-only view as before, matching the prior behavior for already-disabled rows.

## Test plan

- [x] Pre-commit hooks pass (the change is JS only, so ruff and pytest are unchanged; the EOF/whitespace fixers and full pytest suite all ran clean).
- [ ] Manual: in the dev environment, switch the card to Enabled only, disable a slot, confirm the row stays visible during Updating and disappears once the status settles.