### PR TITLE
Gate pytest-homeassistant-custom-component bumps behind dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,12 @@
       "description": "homeassistant is upgraded in lockstep with pytest-homeassistant-custom-component (see AGENTS.md fleet policy). Let helper bumps drive the HA upgrade rather than bumping homeassistant directly."
     },
     {
+      "matchDepNames": ["pytest-homeassistant-custom-component"],
+      "groupName": "homeassistant test helper",
+      "dependencyDashboardApproval": true,
+      "description": "phacc pins an exact homeassistant version, and its newest releases often require an HA prerelease. Because direct homeassistant bumps are disabled (lockstep policy), an auto-opened phacc PR fails pip install against the stable HA pin. Surface phacc bumps on the Dependency Dashboard instead; approve one (and bump homeassistant to match in the same PR) once a stable HA release with a compatible phacc exists."
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true


### PR DESCRIPTION
## Problem

Renovate keeps opening `pytest-homeassistant-custom-component` (phacc) bumps that fail CI at the `pip install` step (most recently PR #109). phacc pins an exact `homeassistant==` version, and its newest releases require a Home Assistant prerelease. Because this repo deliberately disables direct `homeassistant` bumps (the lockstep policy in AGENTS.md, so helper bumps drive the HA upgrade), the auto-opened phacc PR keeps the stable HA pin and pip hits `ResolutionImpossible`. The result is a red PR that cannot go green until a stable HA release with a compatible phacc ships, and Renovate reopens it every cycle.

## Fix

Add a packageRule that pulls phacc into its own group and gates it behind Dependency Dashboard approval. Renovate still surfaces the available phacc bump on the dashboard, but it no longer auto-opens a PR that is guaranteed to fail. When a stable HA release with a compatible phacc is available, approve it from the dashboard and bump `homeassistant` to match in the same PR.

This only changes how phacc updates are surfaced. All other dependency updates (ruff, frontend, GitHub Actions, etc.) keep auto-opening and auto-merging as before.

Renovate config validated with `renovate-config-validator` (passes).