### PR TITLE
Do not automerge action-gh-release digest bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,11 @@
       "description": "pytest is pinned exactly by pytest-homeassistant-custom-component, so an independent pytest bump makes pip resolution impossible (observed 2026-07: pytest 9.1.x vs phacc 0.13.341 pinning pytest==9.0.3). Let phacc bumps drive the pytest upgrade, mirroring the homeassistant lockstep rule above."
     },
     {
+      "matchPackageNames": ["softprops/action-gh-release"],
+      "automerge": false,
+      "description": "Renovate cannot compute a reliable release age for digest bumps of this tag-tracked action (it auto-merged an hours-old release on a sibling repo). Leave these PRs open for a manual merge once the underlying release is 14 days old."
+    },
+    {
       "matchDepNames": ["pytest-homeassistant-custom-component"],
       "groupName": "homeassistant test helper",
       "dependencyDashboardApproval": true,


### PR DESCRIPTION
Renovate cannot compute a reliable release age for digest bumps of this tag-tracked action: on a sibling repo it auto-merged a digest pointing at a release only hours old, bypassing the 14 day supply-chain aging policy. This repo is still on the aged v3.0.1 digest; this rule keeps it that way by leaving future digest PRs for softprops/action-gh-release open until manually merged once the underlying release is 14 days old.